### PR TITLE
Resolve right brackets not being able to be escaped.

### DIFF
--- a/lispbuilder-regex/parser.lisp
+++ b/lispbuilder-regex/parser.lisp
@@ -20,6 +20,7 @@
 
 (defun fix-escape-char (chr)
   (case chr
+    ((#\]) #\])
     ((#\t #\T) #\Tab)
     ((#\n #\N) #\Newline)
     ((#\r #\R) #\Return)
@@ -463,7 +464,7 @@
     (make-range-node expr (car value) (cdr value) t))
    ((eq token 'ngrange)
     (make-range-node expr (car value) (cdr value) nil))
-   (t 
+   (t
     (throw 'regex-parse-error
            (list "quantify: Unexpected quantifier ~S ~S" token value)))))
 
@@ -491,7 +492,7 @@
    ((eq token 'or)
     (unget scanner token value)
     nil)
-   (t 
+   (t
     (throw 'regex-parse-error
            (list "parse-group: Unexpected token ~S ~S" token value)))))
 
@@ -572,6 +573,3 @@
                (characterp lastchar) (char= lastchar #\:))
       (let ((scname (string-downcase (coerce chars 'string))))
         (second (assoc scname +special-class-names+ :test #'string=))))))
-
-
-

--- a/lispbuilder-regex/retest.lisp
+++ b/lispbuilder-regex/retest.lisp
@@ -66,7 +66,7 @@
   (test "(ABC)*DEF" "ABCABCABCDEF" t t)
 
   ;; test character patterns and anchors
-  (test "[\]]" "]" t t)
+  (test "[\\]]" "]" t t)
   (test "[a-z][0-9][z-a][9-0]" "a0a0" t t)
   (test "[a-z][0-9][z-a][9-0]" "A0A0" nil t)
   (test "[^a-z][0-9]" "A0" t t)

--- a/lispbuilder-regex/retest.lisp
+++ b/lispbuilder-regex/retest.lisp
@@ -45,17 +45,17 @@
   (test "A+" "" nil t)
   (test "A+" "A" t t)
   (test "A+" "AA" t t)
-  
+
   ;; test '.' and '?'
   (test ".BC" "ABC" t t)
   (test ".BC" "BC" nil t)
   (test "A?BC" "ABC" t t)
   (test "A?BC" "BC" t t)
-  
+
   ;; test alternation
   (test "A|B" "A" t t)
   (test "(A)|(B)" "B" t t)
-  
+
   ;; more complicated test
   (test "((A*B)|(AC))D" "BD" t t)
   (test "((A*B)|(AC))D" "ABD" t t)
@@ -64,8 +64,9 @@
   (test "((A*B)|(AC))D" "AAABC" nil t)
   (test "((A*B)|(AC))D" "ACD" t t)
   (test "(ABC)*DEF" "ABCABCABCDEF" t t)
-  
+
   ;; test character patterns and anchors
+  (test "[\]]" "]" t t)
   (test "[a-z][0-9][z-a][9-0]" "a0a0" t t)
   (test "[a-z][0-9][z-a][9-0]" "A0A0" nil t)
   (test "[^a-z][0-9]" "A0" t t)
@@ -73,14 +74,14 @@
   (test "^[abcdefg]*$" "abcdefg" t t)
   (test "^[abcdefg]*$" "abcdefgh" nil t)
   (test "^[abcdefg]*$" "ABCDEFG" nil t)
-  
+
   ;; test special character patterns
   (test "[:lower:][:digit:][:upper:][:xdigit:]" "a0A0" t t)
   (test "[:lower:][:digit:][:upper:][:xdigit:]" "a0Aa" t t)
   (test "[:lower:][:digit:][:upper:][:xdigit:]" "a0AA" t t)
   (test "[:lower:][:digit:][:upper:][:xdigit:]" "a0Af" t t)
   (test "[:lower:][:digit:][:upper:][:xdigit:]" "a0AF" t t)
-  
+
   ;; test compiler errors
   (format t "~%~%All of the following should generate compiler errors!")
   (test "(abc" "(abc" nil t)
@@ -89,7 +90,7 @@
   (test "abc)def" "abc" nil t)
   (test "[abc" "[abc" nil t)
   (test "[abc" "abc" nil t)
-;; Unlike the C++ parser, this one treats unattached ] as a normal character 
+;; Unlike the C++ parser, this one treats unattached ] as a normal character
 ;;  (test "abc]def" "abc]def" nil t)
 ;;  (test "abc]def" "abc" nil t)
   (test "[:digit]*" "012345" nil t)
@@ -212,4 +213,3 @@
   (speedtest)
   (format t "~%Done~%")
 )
-


### PR DESCRIPTION
Resolve right brackets not being able to be escaped in the context of a bracketed expression, e.g. [a\\\\]b] should match the strings "a", "]", or "b".


To test against flex:

`
cat > flex-test.l << FLEX_TEST_L
%{
/* need this for the call to getlogin() below */
#include <unistd.h>
%}

%%
[\\\\]]	        printf("Yasss, got a ']'.\n");
%%

int main() {
  yylex();
}
FLEX_TEST_L

flex flex-test.l
gcc lex.yy.c -lfl
echo "]" | ./a.out
`