### PR TITLE
Add ability to use installed sdl libs in osx

### DIFF
--- a/lispbuilder-sdl-image/cffi/library.lisp
+++ b/lispbuilder-sdl-image/cffi/library.lisp
@@ -13,7 +13,8 @@
            :test #'equal))
 
 (cffi:define-foreign-library sdl-image
-    (:darwin (:framework "SDL_image"))
+    (:darwin (:or (:framework "SDL_image")
+                  (:default "libSDL_image")))
     (:windows (:or "SDL_image.dll" "SDL_image1.2.dll"))
     (:unix (:or "libSDL_image-1.2.so.0"
             "libSDL_image1.2"

--- a/lispbuilder-sdl-mixer/cffi/library.lisp
+++ b/lispbuilder-sdl-mixer/cffi/library.lisp
@@ -13,7 +13,8 @@
 	   :test #'equal))
 
 (cffi:define-foreign-library sdl-mixer
-  (:darwin (:framework "SDL_mixer"))
+  (:darwin (:or (:framework "SDL_mixer")
+                (:default "libSDL_mixer")))
   (:windows "SDL_mixer.dll")
   (:unix (:or "libSDL_mixer"
 	      "libSDL_mixer.so"

--- a/lispbuilder-sdl-ttf/cffi/library.lisp
+++ b/lispbuilder-sdl-ttf/cffi/library.lisp
@@ -24,7 +24,8 @@
 
 (cffi:define-foreign-library sdl-ttf
   (:darwin (:or (:framework "SDL_ttf")
-            (:framework "libSDL_ttf-2.0")))
+                (:framework "libSDL_ttf-2.0")
+                (:default "libSDL_ttf-2.0.0")))
   (:windows (:or "SDL_ttf.dll"))
   (:unix (:or "libSDL_ttf" "libSDL_ttf2.0" "libSDL_ttf-2.0.so.0")))
 


### PR DESCRIPTION
Install libs (using homebrew for example) without SDL frameworks. These checks allow to use those libs without installing frameworks.